### PR TITLE
Fix attachment import

### DIFF
--- a/python/fastscore/__init__.py
+++ b/python/fastscore/__init__.py
@@ -2,6 +2,7 @@ from .model import Model
 from .schema import Schema
 from .stream import Stream
 from .sensor import Sensor
+from .attachment import Attachment
 
 from .pneumo import PneumoSock
 


### PR DESCRIPTION
Make Attachment importable from root
```python
from fastscore import Attachment
```
As shown in the documentation.